### PR TITLE
fix 2.7.1 build issue and fail test on z/OS

### DIFF
--- a/src/odbc_connection.cpp
+++ b/src/odbc_connection.cpp
@@ -2125,8 +2125,10 @@ Local<Value> getInfoValue( SQLUSMALLINT fInfoType, SQLPOINTER info )
         case SQL_DATA_SOURCE_NAME          :
         case SQL_DRIVER_NAME               :
         case SQL_DRIVER_VER                :
+#ifndef __MVS__
         case SQL_DRIVER_BLDLEVEL           :
         case SQL_DB2_DRIVER_VER            :
+#endif
         case SQL_ODBC_VER                  :
         case SQL_ROW_UPDATES               :
         case SQL_SERVER_NAME               :
@@ -2135,7 +2137,9 @@ Local<Value> getInfoValue( SQLUSMALLINT fInfoType, SQLPOINTER info )
         case SQL_DBMS_NAME                 :
         case SQL_XOPEN_CLI_YEAR            :
         case SQL_DBMS_VER                  :
+#ifndef __MVS__
         case SQL_DBMS_FUNCTIONLVL          :
+#endif
         case SQL_ACCESSIBLE_TABLES         :
         case SQL_ACCESSIBLE_PROCEDURES     :
         case SQL_DATA_SOURCE_READ_ONLY     :
@@ -2180,7 +2184,9 @@ Local<Value> getInfoValue( SQLUSMALLINT fInfoType, SQLPOINTER info )
         case SQL_MAX_COLUMN_NAME_LEN       :
         case SQL_MAX_CURSOR_NAME_LEN       :
         case SQL_MAX_SCHEMA_NAME_LEN       :
+#ifndef __MVS__
         case SQL_MAX_MODULE_NAME_LEN       :
+#endif
         case SQL_MAX_PROCEDURE_NAME_LEN    :
         case SQL_MAX_TABLE_NAME_LEN        :
         case SQL_TXN_CAPABLE               :
@@ -2222,18 +2228,20 @@ Local<Value> getInfoValue( SQLUSMALLINT fInfoType, SQLPOINTER info )
         case SQL_PARAM_ARRAY_ROW_COUNTS    :
         case SQL_PARAM_ARRAY_SELECTS       :
         case SQL_DTC_TRANSITION_COST       :
+#ifndef __MVS__
         case SQL_DATABASE_CODEPAGE         :
         case SQL_APPLICATION_CODEPAGE      :
         case SQL_CONNECT_CODEPAGE          :
         case SQL_DB2_DRIVER_TYPE           :
+#endif
             result = Nan::New<Number>(*((SQLINTEGER *) info));
             break;
-
+#ifndef __MVS__
         case SQL_INPUT_CHAR_CONVFACTOR     :
         case SQL_OUTPUT_CHAR_CONVFACTOR    :
             result = Nan::New<Number>(*((SQLFLOAT *) info));
             break;
-
+#endif
         // 32 bit binary Mask
         case SQL_CATALOG_USAGE             :
         case SQL_FETCH_DIRECTION           :
@@ -2278,9 +2286,13 @@ Local<Value> getInfoValue( SQLUSMALLINT fInfoType, SQLPOINTER info )
         case SQL_STATIC_SENSITIVITY        :
         case SQL_ALTER_TABLE               :
         case SQL_ALTER_DOMAIN              :
+#ifndef __MVS__
         case SQL_IBM_ALTERTABLEVARCHAR     :
+#endif
         case SQL_SCHEMA_USAGE              :
+#ifndef __MVS__
         case SQL_MODULE_USAGE              :
+#endif
         case SQL_SUBQUERIES                :
         case SQL_TIMEDATE_ADD_INTERVALS    :
         case SQL_TIMEDATE_DIFF_INTERVALS   :
@@ -2292,7 +2304,9 @@ Local<Value> getInfoValue( SQLUSMALLINT fInfoType, SQLPOINTER info )
         case SQL_CREATE_COLLATION          :
         case SQL_CREATE_DOMAIN             :
         case SQL_CREATE_SCHEMA             :
+#ifndef __MVS__
         case SQL_CREATE_MODULE             :
+#endif
         case SQL_CREATE_TABLE              :
         case SQL_CREATE_TRANSLATION        :
         case SQL_CREATE_VIEW               :
@@ -2301,7 +2315,9 @@ Local<Value> getInfoValue( SQLUSMALLINT fInfoType, SQLPOINTER info )
         case SQL_DROP_COLLATION            :
         case SQL_DROP_DOMAIN               :
         case SQL_DROP_SCHEMA               :
+#ifndef __MVS__
         case SQL_DROP_MODULE               :
+#endif
         case SQL_DROP_TABLE                :
         case SQL_DROP_TRANSLATION          :
         case SQL_DROP_VIEW                 :

--- a/src/odbc_connection.cpp
+++ b/src/odbc_connection.cpp
@@ -2125,10 +2125,8 @@ Local<Value> getInfoValue( SQLUSMALLINT fInfoType, SQLPOINTER info )
         case SQL_DATA_SOURCE_NAME          :
         case SQL_DRIVER_NAME               :
         case SQL_DRIVER_VER                :
-#ifndef __MVS__
         case SQL_DRIVER_BLDLEVEL           :
         case SQL_DB2_DRIVER_VER            :
-#endif
         case SQL_ODBC_VER                  :
         case SQL_ROW_UPDATES               :
         case SQL_SERVER_NAME               :
@@ -2137,9 +2135,7 @@ Local<Value> getInfoValue( SQLUSMALLINT fInfoType, SQLPOINTER info )
         case SQL_DBMS_NAME                 :
         case SQL_XOPEN_CLI_YEAR            :
         case SQL_DBMS_VER                  :
-#ifndef __MVS__
         case SQL_DBMS_FUNCTIONLVL          :
-#endif
         case SQL_ACCESSIBLE_TABLES         :
         case SQL_ACCESSIBLE_PROCEDURES     :
         case SQL_DATA_SOURCE_READ_ONLY     :
@@ -2184,9 +2180,7 @@ Local<Value> getInfoValue( SQLUSMALLINT fInfoType, SQLPOINTER info )
         case SQL_MAX_COLUMN_NAME_LEN       :
         case SQL_MAX_CURSOR_NAME_LEN       :
         case SQL_MAX_SCHEMA_NAME_LEN       :
-#ifndef __MVS__
         case SQL_MAX_MODULE_NAME_LEN       :
-#endif
         case SQL_MAX_PROCEDURE_NAME_LEN    :
         case SQL_MAX_TABLE_NAME_LEN        :
         case SQL_TXN_CAPABLE               :
@@ -2228,20 +2222,18 @@ Local<Value> getInfoValue( SQLUSMALLINT fInfoType, SQLPOINTER info )
         case SQL_PARAM_ARRAY_ROW_COUNTS    :
         case SQL_PARAM_ARRAY_SELECTS       :
         case SQL_DTC_TRANSITION_COST       :
-#ifndef __MVS__
         case SQL_DATABASE_CODEPAGE         :
         case SQL_APPLICATION_CODEPAGE      :
         case SQL_CONNECT_CODEPAGE          :
         case SQL_DB2_DRIVER_TYPE           :
-#endif
             result = Nan::New<Number>(*((SQLINTEGER *) info));
             break;
-#ifndef __MVS__
+
         case SQL_INPUT_CHAR_CONVFACTOR     :
         case SQL_OUTPUT_CHAR_CONVFACTOR    :
             result = Nan::New<Number>(*((SQLFLOAT *) info));
             break;
-#endif
+
         // 32 bit binary Mask
         case SQL_CATALOG_USAGE             :
         case SQL_FETCH_DIRECTION           :
@@ -2286,13 +2278,9 @@ Local<Value> getInfoValue( SQLUSMALLINT fInfoType, SQLPOINTER info )
         case SQL_STATIC_SENSITIVITY        :
         case SQL_ALTER_TABLE               :
         case SQL_ALTER_DOMAIN              :
-#ifndef __MVS__
         case SQL_IBM_ALTERTABLEVARCHAR     :
-#endif
         case SQL_SCHEMA_USAGE              :
-#ifndef __MVS__
         case SQL_MODULE_USAGE              :
-#endif
         case SQL_SUBQUERIES                :
         case SQL_TIMEDATE_ADD_INTERVALS    :
         case SQL_TIMEDATE_DIFF_INTERVALS   :
@@ -2304,9 +2292,7 @@ Local<Value> getInfoValue( SQLUSMALLINT fInfoType, SQLPOINTER info )
         case SQL_CREATE_COLLATION          :
         case SQL_CREATE_DOMAIN             :
         case SQL_CREATE_SCHEMA             :
-#ifndef __MVS__
         case SQL_CREATE_MODULE             :
-#endif
         case SQL_CREATE_TABLE              :
         case SQL_CREATE_TRANSLATION        :
         case SQL_CREATE_VIEW               :
@@ -2315,9 +2301,7 @@ Local<Value> getInfoValue( SQLUSMALLINT fInfoType, SQLPOINTER info )
         case SQL_DROP_COLLATION            :
         case SQL_DROP_DOMAIN               :
         case SQL_DROP_SCHEMA               :
-#ifndef __MVS__
         case SQL_DROP_MODULE               :
-#endif
         case SQL_DROP_TABLE                :
         case SQL_DROP_TRANSLATION          :
         case SQL_DROP_VIEW                 :

--- a/src/odbc_connection.h
+++ b/src/odbc_connection.h
@@ -33,6 +33,62 @@
   #define SQL_DBMS_FUNCTIONLVL 203
 #endif
 
+#ifndef SQL_DRIVER_BLDLEVEL 
+  #define SQL_DRIVER_BLDLEVEL 2604
+#endif
+
+#ifndef SQL_DB2_DRIVER_VER
+  #define SQL_DB2_DRIVER_VER 2550
+#endif
+
+#ifndef SQL_MAX_MODULE_NAME_LEN
+  #define SQL_MAX_MODULE_NAME_LEN 2603
+#endif
+
+#ifndef SQL_DATABASE_CODEPAGE
+  #define SQL_DATABASE_CODEPAGE 2519
+#endif
+
+#ifndef SQL_APPLICATION_CODEPAGE
+  #define SQL_APPLICATION_CODEPAGE 2520
+#endif
+
+#ifndef SQL_CONNECT_CODEPAGE
+  #define SQL_CONNECT_CODEPAGE 2521
+#endif
+
+#ifndef SQL_DB2_DRIVER_TYPE
+  #define SQL_DB2_DRIVER_TYPE 2567
+#endif
+
+#ifndef SQL_INPUT_CHAR_CONVFACTOR 
+  #define SQL_INPUT_CHAR_CONVFACTOR 2581
+#endif
+
+#ifndef SQL_OUTPUT_CHAR_CONVFACTOR 
+  #define SQL_OUTPUT_CHAR_CONVFACTOR 2582
+#endif
+
+#ifndef SQL_IBM_ALTERTABLEVARCHAR 
+  #define SQL_IBM_ALTERTABLEVARCHAR 1000
+#endif
+
+#ifndef SQL_MODULE_USAGE 
+  #define SQL_MODULE_USAGE 2601
+#endif
+
+#ifndef SQL_CREATE_MODULE 
+  #define SQL_CREATE_MODULE 2602
+#endif
+
+#ifndef SQL_DROP_MODULE 
+  #define SQL_DROP_MODULE 2600
+#endif
+
+#ifdef __MVS__
+typedef SDOUBLE SQLFLOAT;
+#endif
+
 class ODBCConnection : public Nan::ObjectWrap {
   public:
    static Nan::Persistent<String> OPTION_SQL;

--- a/test/test-basic-test.js
+++ b/test/test-basic-test.js
@@ -14,7 +14,7 @@ ibmdb.open(cn, {"fetchMode": 3}, function(err, conn) { // 3 means FETCH_ARRARY
     conn.querySync("drop table mytab1");
   } catch (e) {}
   if (platform == 'os390') {
-    conn.querySync("create table mytab1 (c1 int, c2 varchar(10)), c3 blob(100) ccsid UNICODE");
+    conn.querySync("create table mytab1 (c1 int, c2 varchar(10), c3 blob(100)) ccsid UNICODE");
   } else {
     conn.querySync("create table mytab1 (c1 int, c2 varchar(10), c3 blob(100))");
   }

--- a/test/test-sp-dbc-6000.js
+++ b/test/test-sp-dbc-6000.js
@@ -13,7 +13,7 @@ if (process.env.IBM_DB_SERVER_TYPE !== "ZOS") {
     return;
 }
 
-var proc = "CREATE PROCEDURE SYSPROC.TBV8930 (in vlog_header varchar(200), out  return_code char(05), out sql_code integer, out result varchar(200)) language sql commit on return no query acceleration NONE asutime LIMIT 5002 reads sql data dynamic result sets 1 package owner DVLPP with explain MAIN: BEGIN declare sqlcode integer; declare sqlstate char(5); declare c1 cursor with return for select lower(vlog_header) as vlog_header from sysibm.sysdummy1; set result = upper(vlog_header) ; set return_code = '00000' , sql_code = 0 ; open c1; END MAIN"; 
+var proc = "CREATE PROCEDURE SYSPROC.TBV8930 (in vlog_header varchar(200), out  return_code char(05), out sql_code integer, out result varchar(200)) language sql commit on return no asutime LIMIT 5002 DISABLE DEBUG MODE reads sql data dynamic result sets 1 package owner DVLPP with explain MAIN: BEGIN declare sqlcode integer; declare sqlstate char(5); declare c1 cursor with return for select lower(vlog_header) as vlog_header from sysibm.sysdummy1; set result = upper(vlog_header) ; set return_code = '00000' , sql_code = 0 ; open c1; END MAIN"; 
 
 var query = "call SYSPROC.TBV8930(?, ?, ?, ?)";
 var result;


### PR DESCRIPTION
ibm_db 2.7.1 failed to build on z/OS because of the unsupported InfoType. This PR is to resolve the issue among other new fail tests.

In `test-sp-dbc-6000.js` I add `DISABLE DEBUG MODE` so it doesn't require a wlm environment to run, and remove `query acceleration NONE` because it failed when the db2 have the acceleration disabled. 